### PR TITLE
Improve error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Don't upload to Surge if the job is cancelled.
+
 ### Changed
 
 - Update Backstop 6.2.2 -> 6.3.25.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Don't upload to Surge if the job is cancelled.
+- Run `backstop test` even if `backstop reference` reference fails.
 
 ### Changed
 

--- a/action.yml
+++ b/action.yml
@@ -78,6 +78,7 @@ runs:
       run: npx backstop --config backstop.js test
       shell: bash
       working-directory: ${{ inputs.local-backstop-directory || github.action_path }}
+      if: '!cancelled()'
     - name: Upload the HTML report to Surge.sh.
       if: '!cancelled()'
       run: |

--- a/action.yml
+++ b/action.yml
@@ -79,7 +79,7 @@ runs:
       shell: bash
       working-directory: ${{ inputs.local-backstop-directory || github.action_path }}
     - name: Upload the HTML report to Surge.sh.
-      if: always()
+      if: '!cancelled()'
       run: |
         npm install -g surge &&
         surge . ${{ inputs.vrt-domain }} --token ${{ inputs.surge-token }} >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
- [fix: don't upload to Surge if the job is cancelled](https://github.com/BrooksDigital/visual-regression-testing/commit/dbdd3210b3f426b95d38a788cd898bfe3bfdcf02)
- [fix: run backstop test even if reference fails](https://github.com/BrooksDigital/visual-regression-testing/commit/c81711feb7731ff3e7c651b93ca6549d06afc851): I'm seeing a `backstop reference` end in an error but it's still displaying the message to run 'backstop test'. I'm not sure what the error is (because the error reporting converts the error object to a string so we just see `[object Object]`!) but nothing looks obviously awful about the reference run, so change behavior to run `backstop test` even if `backstop reference` exits with a failure code.